### PR TITLE
Version 2.1 - Fix SqlBlobProvider media extraction compatibility with Optimizely Graph

### DIFF
--- a/src/EPiCode.SqlBlobProvider/EPiCode.SqlBlobProvider.csproj
+++ b/src/EPiCode.SqlBlobProvider/EPiCode.SqlBlobProvider.csproj
@@ -5,14 +5,15 @@
         <AssemblyTitle>EPiCode.SqlBlobProvider</AssemblyTitle>
         <Company>BV Network AS</Company>
         <Product>EPiCode.SqlBlobProvider</Product>
-        <Version>2.0.0</Version>
+        <Version>2.1.0</Version>
     </PropertyGroup>
     <PropertyGroup>
         <Title>EPiCode.SqlBlobProvider</Title>
-        <Authors>Per Magne Skuseth, Steve Celius, Karol Berezicki</Authors>
+        <Authors>Per Magne Skuseth, Steve Celius, Karol Berezicki, Luc Gosso</Authors>
         <PackageProjectUrl>https://github.com/BVNetwork/SqlBlobProvider</PackageProjectUrl>
-        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
         <Description>A blob provider which stores all blobs in the SQL database (for the CMS) instead of disk, S3 or Azure blob storage</Description>
+        <PackageReleaseNotes>2.1.0 - Improved Optimizely Graph media extraction compatibility by adding proper blob existence checks, clearer missing-blob handling, and FileInfo support for SQL-backed blobs.</PackageReleaseNotes>
         <PackageTags>EPiServer Blob</PackageTags>
     </PropertyGroup>
     <ItemGroup>
@@ -20,6 +21,7 @@
         <PackageReference Include="EPiServer.Framework" Version="12.21.1"/>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0"/>
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="8.0.0"/>    
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     </ItemGroup>
 </Project>

--- a/src/EPiCode.SqlBlobProvider/FileHelper.cs
+++ b/src/EPiCode.SqlBlobProvider/FileHelper.cs
@@ -58,7 +58,13 @@ class FileHelper
             return new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
-        var bytes = SqlBlobModelRepository.Get(id).Blob;
+        var blobModel = SqlBlobModelRepository.Get(id);
+        if (blobModel?.Blob == null)
+        {
+            throw new FileNotFoundException($"Blob not found for id '{id}'.", id.ToString());
+        }
+
+        var bytes = blobModel.Blob;
         var directoryInfo = new DirectoryInfo(Path.GetDirectoryName(filePath) ?? string.Empty);
         if (!directoryInfo.Exists)
         {

--- a/src/EPiCode.SqlBlobProvider/SqlBlob.cs
+++ b/src/EPiCode.SqlBlobProvider/SqlBlob.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using EPiServer.Framework.Blobs;
+using Microsoft.Extensions.FileProviders;
+using System.Threading.Tasks;
 // ReSharper disable MemberCanBePrivate.Global
 // ReSharper disable ConvertToPrimaryConstructor
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
@@ -23,10 +25,40 @@ public class SqlBlob : Blob
     {
         if (!LoadFromDisk)
         {
-            return new NonSeekableMemoryStream(SqlBlobModelRepository.Get(ID).Blob);
+            var blobModel = SqlBlobModelRepository.Get(ID);
+            if (blobModel?.Blob == null)
+            {
+                throw new FileNotFoundException($"Blob not found for id '{ID}'.", ID.ToString());
+            }
+
+            return new NonSeekableMemoryStream(blobModel.Blob);
         }
 
         return FileHelper.GetOrCreateFileBlob(FilePath, ID);
+    }
+
+    public override Task<IFileInfo> AsFileInfoAsync(DateTimeOffset? lastModified = null)
+    {
+        var exists = false;
+        long length = -1;
+
+        if (LoadFromDisk && !string.IsNullOrWhiteSpace(FilePath) && File.Exists(FilePath))
+        {
+            var fileInfo = new FileInfo(FilePath);
+            exists = true;
+            length = fileInfo.Length;
+        }
+        else
+        {
+            var blobModel = SqlBlobModelRepository.Get(ID);
+            if (blobModel?.Blob != null)
+            {
+                exists = true;
+                length = blobModel.Blob.LongLength;
+            }
+        }
+
+        return Task.FromResult<IFileInfo>(new SqlBlobFileInfo(this, exists, length, lastModified));
     }
 
     public override Stream OpenWrite()
@@ -69,5 +101,36 @@ public class SqlBlob : Blob
         }
 
         SqlBlobModelRepository.Save(sqlBlobModel);
+    }
+
+    private sealed class SqlBlobFileInfo : IFileInfo
+    {
+        private readonly SqlBlob _blob;
+        private readonly DateTimeOffset? _lastModified;
+
+        public SqlBlobFileInfo(SqlBlob blob, bool exists, long length, DateTimeOffset? lastModified)
+        {
+            _blob = blob;
+            Exists = exists;
+            Length = length;
+            _lastModified = lastModified;
+        }
+
+        public bool Exists { get; }
+        public long Length { get; }
+        public string PhysicalPath => _blob.FilePath;
+        public string Name => Path.GetFileName(_blob.FilePath);
+        public DateTimeOffset LastModified => _lastModified ?? DateTimeOffset.UtcNow;
+        public bool IsDirectory => false;
+
+        public Stream CreateReadStream()
+        {
+            if (!Exists)
+            {
+                throw new FileNotFoundException($"Blob not found for id '{_blob.ID}'.", _blob.ID.ToString());
+            }
+
+            return _blob.OpenRead();
+        }
     }
 }

--- a/src/EPiCode.SqlBlobProvider/SqlBlobProvider.cs
+++ b/src/EPiCode.SqlBlobProvider/SqlBlobProvider.cs
@@ -72,7 +72,7 @@ public class SqlBlobProvider : BlobProvider
 
     public override Blob GetBlob(Uri id)
     {
-        return new SqlBlob(id, System.IO.Path.Combine(Path, id.AbsolutePath[1..]), LoadFromDisk);
+         return new SqlBlob(id, System.IO.Path.Combine(Path, id.AbsolutePath[1..]), LoadFromDisk);
     }
 
     public override Blob CreateBlob(Uri id, string extension)


### PR DESCRIPTION
- Bump version number 2.1
- Add proper missing-blob handling in SqlBlob and FileHelper (avoid null reference, throw clear file-not-found). 
- Implement AsFileInfoAsync(DateTimeOffset?) in SqlBlob with correct Exists/Length behavior.
- Add Microsoft.Extensions.FileProviders.Abstractions package reference required for IFileInfo.
- This enables Optimizely Graph media extraction flow to correctly detect missing ExtractedMediaInformation_*.json blobs and proceed as expected.